### PR TITLE
bwc-installer.sh should also install suite if --suite option is supplied

### DIFF
--- a/scripts/bwc-ipfabric-suite-installer-deb.sh
+++ b/scripts/bwc-ipfabric-suite-installer-deb.sh
@@ -24,6 +24,7 @@ to purchase or trial BWC.
 Please contact sales@brocade.com if you have any questions.
 "
 
+# XXX: Once we have our S3 buckets set up, point these to public URLs.
 SETUP_SCRIPTS_BASE_PATH="https://raw.githubusercontent.com/StackStorm/bwc-installer/${BRANCH}/scripts/setup"
 
 fail() {

--- a/scripts/bwc-ipfabric-suite-installer-el6.sh
+++ b/scripts/bwc-ipfabric-suite-installer-el6.sh
@@ -23,6 +23,7 @@ to purchase or trial BWC.
 Please contact sales@brocade.com if you have any questions.
 "
 
+# XXX: Once we have our S3 buckets set up, point these to public URLs.
 SETUP_SCRIPTS_BASE_PATH="https://raw.githubusercontent.com/StackStorm/bwc-installer/${BRANCH}/scripts/setup"
 
 fail() {

--- a/scripts/bwc-ipfabric-suite-installer-el7.sh
+++ b/scripts/bwc-ipfabric-suite-installer-el7.sh
@@ -23,6 +23,7 @@ to purchase or trial BWC.
 Please contact sales@brocade.com if you have any questions.
 "
 
+# XXX: Once we have our S3 buckets set up, point these to public URLs.
 SETUP_SCRIPTS_BASE_PATH="https://raw.githubusercontent.com/StackStorm/bwc-installer/${BRANCH}/scripts/setup"
 
 fail() {

--- a/scripts/bwc-suite-installer.sh
+++ b/scripts/bwc-suite-installer.sh
@@ -13,6 +13,8 @@ BRANCH='master'
 LICENSE_KEY=''
 
 SUITES_LIST=(bwc-ipfabric-suite) # Space separated list of names that should map to package names.
+
+# XXX: Once we have our S3 buckets set up, point these to public URLs.
 BASE_PATH="https://raw.githubusercontent.com/StackStorm/bwc-installer"
 
 SUITE=''


### PR DESCRIPTION
## Why?

@dzimine was writing docs for ipfabric installation and the two script approach to install bwc and then the suite on top wasn't ideal. He now wants one curl command but only if --suite option is supplied, he wants to install suite on top of bwc. 

## Sample run 

./bwc-installer.sh --user=st2admin --password=<REDACTED> --staging --unstable --suite=bwc-ipfabric-suite --license=<REDACTED>

## Sample logs
https://gist.github.com/lakshmi-kannan/a22482e81c5d467570623008a550dca9