### PR TITLE
Enable and configure RBAC after BWC installation

### DIFF
--- a/scripts/bwc-installer-deb.sh
+++ b/scripts/bwc-installer-deb.sh
@@ -148,7 +148,7 @@ enable_and_configure_rbac() {
   sudo crudini --set /etc/st2/st2.conf rbac enable 'True'
 
   # Write default admin role assignment for the admin user
-  ROLE_ASSIGNMENT_FILE="/opt/stackstorm/rbac/assignments/${username}.yaml"
+  ROLE_ASSIGNMENT_FILE="/opt/stackstorm/rbac/assignments/${USERNAME}.yaml"
   sudo cat > ${ROLE_ASSIGNMENT_FILE} <<EOL
 ---
   username: "${USERNAME}"

--- a/scripts/bwc-installer-deb.sh
+++ b/scripts/bwc-installer-deb.sh
@@ -142,18 +142,26 @@ enable_and_configure_rbac() {
   sudo apt-get install -y crudini
   sudo crudini --set /etc/st2/st2.conf rbac enable 'True'
 
-  # Write default admin role assignment for the admin user
-
   # TODO: Move directory creation to package
   sudo mkdir -p /opt/stackstorm/rbac/assignments/
   sudo mkdir -p /opt/stackstorm/rbac/roles/
 
+  # Write role assignment for admin user
   ROLE_ASSIGNMENT_FILE="/opt/stackstorm/rbac/assignments/${USERNAME}.yaml"
   sudo bash -c "cat > ${ROLE_ASSIGNMENT_FILE}" <<EOL
 ---
   username: "${USERNAME}"
   roles:
     - "system_admin"
+EOL
+
+  # Write role assignment for stanley (system) user
+  ROLE_ASSIGNMENT_FILE="/opt/stackstorm/rbac/assignments/stanley.yaml"
+  sudo bash -c "cat > ${ROLE_ASSIGNMENT_FILE}" <<EOL
+---
+  username: "stanley"
+  roles:
+    - "admin"
 EOL
 
   # Sync roles and assignments

--- a/scripts/bwc-installer-deb.sh
+++ b/scripts/bwc-installer-deb.sh
@@ -128,8 +128,14 @@ get_full_pkg_versions() {
 }
 
 install_bwc_enterprise() {
+  # Install BWC
   sudo apt-get update
   sudo apt-get -y install bwc-enterprise${BWC_ENTERPRISE_VERSION}
+
+  # Enable RBAC
+  sudo apt-get install -y crudini
+  sudo crudini --set /etc/st2/st2.conf rbac enable 'True'
+  sudo st2ctl restart-component st2api
 }
 
 ok_message() {

--- a/scripts/bwc-installer-deb.sh
+++ b/scripts/bwc-installer-deb.sh
@@ -135,11 +135,6 @@ install_bwc_enterprise() {
   # Install BWC
   sudo apt-get update
   sudo apt-get -y install bwc-enterprise${BWC_ENTERPRISE_VERSION}
-
-  # Enable RBAC
-  sudo apt-get install -y crudini
-  sudo crudini --set /etc/st2/st2.conf rbac enable 'True'
-  sudo st2ctl restart-component st2api
 }
 
 enable_and_configure_rbac() {
@@ -154,7 +149,7 @@ enable_and_configure_rbac() {
   sudo mkdir -p /opt/stackstorm/rbac/roles/
 
   ROLE_ASSIGNMENT_FILE="/opt/stackstorm/rbac/assignments/${USERNAME}.yaml"
-  sudo cat > ${ROLE_ASSIGNMENT_FILE} <<EOL
+  sudo bash -c "cat > ${ROLE_ASSIGNMENT_FILE}" <<EOL
 ---
   username: "${USERNAME}"
   roles:

--- a/scripts/bwc-installer-deb.sh
+++ b/scripts/bwc-installer-deb.sh
@@ -148,6 +148,11 @@ enable_and_configure_rbac() {
   sudo crudini --set /etc/st2/st2.conf rbac enable 'True'
 
   # Write default admin role assignment for the admin user
+
+  # TODO: Move directory creation to package
+  sudo mkdir -p /opt/stackstorm/rbac/assignments/
+  sudo mkdir -p /opt/stackstorm/rbac/roles/
+
   ROLE_ASSIGNMENT_FILE="/opt/stackstorm/rbac/assignments/${USERNAME}.yaml"
   sudo cat > ${ROLE_ASSIGNMENT_FILE} <<EOL
 ---

--- a/scripts/bwc-installer-el6.sh
+++ b/scripts/bwc-installer-el6.sh
@@ -46,6 +46,10 @@ setup_args() {
           REPO_TYPE='staging'
           shift
           ;;
+          --user=*)
+          USERNAME="${i#*=}"
+          shift
+          ;;
           --license=*)
           LICENSE_KEY="${i#*=}"
           shift

--- a/scripts/bwc-installer-el6.sh
+++ b/scripts/bwc-installer-el6.sh
@@ -138,7 +138,7 @@ install_bwc_enterprise() {
 
 enable_and_configure_rbac() {
   # Enable RBAC
-  sudo apt-get install -y crudini
+  sudo yum -y install crudini
   sudo crudini --set /etc/st2/st2.conf rbac enable 'True'
 
   # Write default admin role assignment for the admin user

--- a/scripts/bwc-installer-el6.sh
+++ b/scripts/bwc-installer-el6.sh
@@ -141,18 +141,26 @@ enable_and_configure_rbac() {
   sudo yum -y install crudini
   sudo crudini --set /etc/st2/st2.conf rbac enable 'True'
 
-  # Write default admin role assignment for the admin user
-
   # TODO: Move directory creation to package
   sudo mkdir -p /opt/stackstorm/rbac/assignments/
   sudo mkdir -p /opt/stackstorm/rbac/roles/
 
+  # Write role assignment for admin user
   ROLE_ASSIGNMENT_FILE="/opt/stackstorm/rbac/assignments/${USERNAME}.yaml"
   sudo bash -c "cat > ${ROLE_ASSIGNMENT_FILE}" <<EOL
 ---
   username: "${USERNAME}"
   roles:
     - "system_admin"
+EOL
+
+  # Write role assignment for stanley (system) user
+  ROLE_ASSIGNMENT_FILE="/opt/stackstorm/rbac/assignments/stanley.yaml"
+  sudo bash -c "cat > ${ROLE_ASSIGNMENT_FILE}" <<EOL
+---
+  username: "stanley"
+  roles:
+    - "admin"
 EOL
 
   # Sync roles and assignments

--- a/scripts/bwc-installer-el6.sh
+++ b/scripts/bwc-installer-el6.sh
@@ -128,7 +128,13 @@ get_full_pkg_versions() {
 }
 
 install_bwc_enterprise() {
+  # Install BWC
   sudo yum -y install ${BWC_ENTERPRISE_PKG}
+
+  # Enable RBAC
+  sudo yum -y install crudini
+  sudo crudini --set /etc/st2/st2.conf rbac enable 'True'
+  sudo st2ctl restart-component st2api
 }
 
 ok_message() {

--- a/scripts/bwc-installer-el7.sh
+++ b/scripts/bwc-installer-el7.sh
@@ -46,6 +46,10 @@ setup_args() {
           REPO_TYPE='staging'
           shift
           ;;
+          --user=*)
+          USERNAME="${i#*=}"
+          shift
+          ;;
           --license=*)
           LICENSE_KEY="${i#*=}"
           shift

--- a/scripts/bwc-installer-el7.sh
+++ b/scripts/bwc-installer-el7.sh
@@ -138,7 +138,7 @@ install_bwc_enterprise() {
 
 enable_and_configure_rbac() {
   # Enable RBAC
-  sudo apt-get install -y crudini
+  sudo yum -y install crudini
   sudo crudini --set /etc/st2/st2.conf rbac enable 'True'
 
   # Write default admin role assignment for the admin user

--- a/scripts/bwc-installer-el7.sh
+++ b/scripts/bwc-installer-el7.sh
@@ -141,18 +141,26 @@ enable_and_configure_rbac() {
   sudo yum -y install crudini
   sudo crudini --set /etc/st2/st2.conf rbac enable 'True'
 
-  # Write default admin role assignment for the admin user
-
   # TODO: Move directory creation to package
   sudo mkdir -p /opt/stackstorm/rbac/assignments/
   sudo mkdir -p /opt/stackstorm/rbac/roles/
 
+  # Write role assignment for admin user
   ROLE_ASSIGNMENT_FILE="/opt/stackstorm/rbac/assignments/${USERNAME}.yaml"
   sudo bash -c "cat > ${ROLE_ASSIGNMENT_FILE}" <<EOL
 ---
   username: "${USERNAME}"
   roles:
     - "system_admin"
+EOL
+
+  # Write role assignment for stanley (system) user
+  ROLE_ASSIGNMENT_FILE="/opt/stackstorm/rbac/assignments/stanley.yaml"
+  sudo bash -c "cat > ${ROLE_ASSIGNMENT_FILE}" <<EOL
+---
+  username: "stanley"
+  roles:
+    - "admin"
 EOL
 
   # Sync roles and assignments

--- a/scripts/bwc-installer-el7.sh
+++ b/scripts/bwc-installer-el7.sh
@@ -128,7 +128,13 @@ get_full_pkg_versions() {
 }
 
 install_bwc_enterprise() {
+  # Install BWC
   sudo yum -y install ${BWC_ENTERPRISE_PKG}
+
+  # Enable RBAC
+  sudo yum -y install crudini
+  sudo crudini --set /etc/st2/st2.conf rbac enable 'True'
+  sudo st2ctl restart-component st2api
 }
 
 ok_message() {

--- a/scripts/bwc-installer.sh
+++ b/scripts/bwc-installer.sh
@@ -1,4 +1,4 @@
-sudo #! /bin/bash
+#! /bin/bash
 
 set -u
 
@@ -59,10 +59,6 @@ setup_args() {
           ;;
           --password=*)
           PASSWORD="${i#*=}"
-          shift
-          ;;
-          --branch=*)
-          BRANCH="${i#*=}"
           shift
           ;;
           --license=*)

--- a/scripts/bwc-installer.sh
+++ b/scripts/bwc-installer.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+sudo #! /bin/bash
 
 set -u
 
@@ -59,6 +59,10 @@ setup_args() {
           ;;
           --password=*)
           PASSWORD="${i#*=}"
+          shift
+          ;;
+          --branch=*)
+          BRANCH="${i#*=}"
           shift
           ;;
           --license=*)


### PR DESCRIPTION
This PR enabled RBAC in st2.conf after installing BWC.

In addition to that it also writes a default role assignment for the admin user and synchronizes the roles.

There was a regression when we moved from StackStorm Enterprise to BWC (RBAC wasn't automatically enabled).

## TODO

- [x] Write default role assignment (admin for installation user)