### PR TITLE
Use safer and non-deterministic (random) password generation method

### DIFF
--- a/scripts/bwc-ipfabric-suite-installer-deb.sh
+++ b/scripts/bwc-ipfabric-suite-installer-deb.sh
@@ -169,7 +169,7 @@ setup_ipfabric_automation_suite() {
 
   # echo "Running deployment script for Brocade Workflow Composer ${VERSION}..."
   echo "Generating DB password for bwc-topology postgres database"
-  local DB_PASSWORD=$(date +%s | sha256sum | base64 | head -c 32 ; echo)
+  local DB_PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32 ; echo '')
   echo "OS specific script cmd: bash ${IPFABRIC_SETUP_FILE} --bwc-db-password=${DB_PASSWORD}"
 
   local ST2_TOKEN=$(st2 auth ${USERNAME} -p ${PASSWORD} -t)

--- a/scripts/bwc-ipfabric-suite-installer-el6.sh
+++ b/scripts/bwc-ipfabric-suite-installer-el6.sh
@@ -167,7 +167,7 @@ setup_ipfabric_automation_suite() {
 
   # echo "Running deployment script for Brocade Workflow Composer ${VERSION}..."
   echo "Generating DB password for bwc-topology postgres database"
-  local DB_PASSWORD=$(date +%s | sha256sum | base64 | head -c 32 ; echo)
+  local DB_PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32 ; echo '')
   echo "OS specific script cmd: bash ${IPFABRIC_SETUP_FILE} --bwc-db-password=${DB_PASSWORD}"
 
   local ST2_TOKEN=$(st2 auth ${USERNAME} -p ${PASSWORD} -t)

--- a/scripts/bwc-ipfabric-suite-installer-el7.sh
+++ b/scripts/bwc-ipfabric-suite-installer-el7.sh
@@ -167,7 +167,7 @@ setup_ipfabric_automation_suite() {
 
   # echo "Running deployment script for Brocade Workflow Composer ${VERSION}..."
   echo "Generating DB password for bwc-topology postgres database"
-  local DB_PASSWORD=$(date +%s | sha256sum | base64 | head -c 32 ; echo)
+  local DB_PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32 ; echo '')
   echo "OS specific script cmd: bash ${IPFABRIC_SETUP_FILE} --bwc-db-password=${DB_PASSWORD}"
 
   local ST2_TOKEN=$(st2 auth ${USERNAME} -p ${PASSWORD} -t)

--- a/scripts/dcfabric-suite-installer-deb.sh
+++ b/scripts/dcfabric-suite-installer-deb.sh
@@ -169,7 +169,7 @@ setup_ipfabric_automation_suite() {
 
   # echo "Running deployment script for Brocade Workflow Composer ${VERSION}..."
   echo "Generating DB password for network-essentials postgres database"
-  local DB_PASSWORD=$(date +%s | sha256sum | base64 | head -c 32 ; echo)
+  local DB_PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32 ; echo '')
   echo "OS specific script cmd: bash ${IPFABRIC_SETUP_FILE} --bwc-db-password=${DB_PASSWORD}"
 
   local ST2_TOKEN=$(st2 auth ${USERNAME} -p ${PASSWORD} -t)

--- a/scripts/dcfabric-suite-installer-el6.sh
+++ b/scripts/dcfabric-suite-installer-el6.sh
@@ -167,7 +167,7 @@ setup_ipfabric_automation_suite() {
 
   # echo "Running deployment script for Brocade Workflow Composer ${VERSION}..."
   echo "Generating DB password for network-essentials postgres database"
-  local DB_PASSWORD=$(date +%s | sha256sum | base64 | head -c 32 ; echo)
+  local DB_PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32 ; echo '')
   echo "OS specific script cmd: bash ${IPFABRIC_SETUP_FILE} --bwc-db-password=${DB_PASSWORD}"
 
   local ST2_TOKEN=$(st2 auth ${USERNAME} -p ${PASSWORD} -t)

--- a/scripts/dcfabric-suite-installer-el7.sh
+++ b/scripts/dcfabric-suite-installer-el7.sh
@@ -167,7 +167,7 @@ setup_ipfabric_automation_suite() {
 
   # echo "Running deployment script for Brocade Workflow Composer ${VERSION}..."
   echo "Generating DB password for network-essentials postgres database"
-  local DB_PASSWORD=$(date +%s | sha256sum | base64 | head -c 32 ; echo)
+  local DB_PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32 ; echo '')
   echo "OS specific script cmd: bash ${IPFABRIC_SETUP_FILE} --bwc-db-password=${DB_PASSWORD}"
 
   local ST2_TOKEN=$(st2 auth ${USERNAME} -p ${PASSWORD} -t)


### PR DESCRIPTION
Previous approach used current date method which was deterministic which means that in theory, the password could be guessed / inferred.

This pull request changes it to use a more secure source from `/dev/urandom` which is a preferred source for cryptographic randomness.

(yeah in theory using date in this case is not such a big deal, but still better to be safe than sorry)

/cc @lakshmi-kannan 