### PR TITLE
Remove --head from install-suite.sh

### DIFF
--- a/scripts/bwc-suite-installer.sh
+++ b/scripts/bwc-suite-installer.sh
@@ -137,7 +137,7 @@ fi
 
 hash curl 2>/dev/null || { echo >&2 "'curl' is not installed. Aborting."; exit 1; }
 
-CURLTEST=`curl --output /dev/null --silent --head --fail ${SUITE_OS_INSTALLER}`
+CURLTEST=`curl --output /dev/null --silent --fail ${SUITE_OS_INSTALLER}`
 if [ $? -ne 0 ]; then
     echo -e "Could not find file ${SUITE_OS_INSTALLER}"
     exit 2


### PR DESCRIPTION
Same fix as https://github.com/StackStorm/bwc-installer/pull/25, but for the suite-specific installation script.

Have to remove `--head` because of WP plugin changes causing 404s for HEAD requests