### PR TITLE
Fixing the el6 and el7 installation scripts and updated the variable name from the deb installation script.

### DIFF
--- a/scripts/dcfabric-suite-installer-deb.sh
+++ b/scripts/dcfabric-suite-installer-deb.sh
@@ -14,7 +14,7 @@ BRANCH='master'
 REPO_NAME='enterprise'
 
 SUITE='dcfabric-suite'
-IPFABRIC_SUITE_VERSION=''
+DCFABRIC_SUITE_VERSION=''
 
 NO_LICENSE_BANNER="
 LICENSE KEY not provided. You'll need a license key to install Brocade Workflow Composer (BWC).
@@ -141,20 +141,20 @@ get_full_pkg_versions() {
       exit 3
     fi
 
-    IPFABRIC_SUITE_VERSION="=${IPF_VER}"
+    DCFABRIC_SUITE_VERSION="=${IPF_VER}"
     echo "##########################################################"
     echo "#### Following versions of packages will be installed ####"
-    echo "${SUITE}${IPFABRIC_SUITE_VERSION}"
+    echo "${SUITE}${DCFABRIC_SUITE_VERSION}"
     echo "##########################################################"
   fi
 }
 
 install_network_essentials_pack() {
-  sudo st2 pack install network_essentials=${IPFABRIC_SUITE_VERSION}
+  sudo st2 pack install network_essentials=${DCFABRIC_SUITE_VERSION}
 }
 
 install_ipfabric_automation_suite() {
-  sudo apt-get -y install ${SUITE}${IPFABRIC_SUITE_VERSION}
+  sudo apt-get -y install ${SUITE}${DCFABRIC_SUITE_VERSION}
 }
 
 setup_ipfabric_automation_suite() {

--- a/scripts/dcfabric-suite-installer-el6.sh
+++ b/scripts/dcfabric-suite-installer-el6.sh
@@ -155,7 +155,7 @@ install_network_essentials_pack() {
 }
 
 install_ipfabric_automation_suite() {
-  sudo yum -y install ${SUITE} - ${DCFABRIC_SUITE_VERSION} --skip-broken
+  sudo yum -y install ${SUITE} - ${DCFABRIC_SUITE_VERSION}
 }
 
 setup_ipfabric_automation_suite() {

--- a/scripts/dcfabric-suite-installer-el6.sh
+++ b/scripts/dcfabric-suite-installer-el6.sh
@@ -14,6 +14,7 @@ BRANCH='master'
 REPO_NAME='enterprise'
 
 SUITE='dcfabric-suite'
+DCFABRIC_SUITE_VERSION=''
 
 NO_LICENSE_BANNER="
 LICENSE KEY not provided. You'll need a license key to install Brocade Workflow Composer (BWC).
@@ -140,6 +141,7 @@ get_full_pkg_versions() {
     fi
 
     SUITE=${IPF_VER}
+    DCFABRIC_SUITE_VERSION="=${IPF_VER}"
     echo "##########################################################"
     echo "#### Following versions of packages will be installed ####"
     echo "${IPFABRIC_SUITE_PKG}"
@@ -148,11 +150,12 @@ get_full_pkg_versions() {
 }
 
 install_network_essentials_pack() {
-  sudo st2 pack install network_essentials=${IPFABRIC_SUITE_VERSION}
+  sudo yum -y install gcc
+  sudo st2 pack install network_essentials=${DCFABRIC_SUITE_VERSION}
 }
 
 install_ipfabric_automation_suite() {
-  sudo yum -y install ${SUITE}
+  sudo yum -y install ${SUITE} - ${DCFABRIC_SUITE_VERSION} --skip-broken
 }
 
 setup_ipfabric_automation_suite() {

--- a/scripts/dcfabric-suite-installer-el7.sh
+++ b/scripts/dcfabric-suite-installer-el7.sh
@@ -155,7 +155,7 @@ install_network_essentials_pack() {
 }
 
 install_ipfabric_automation_suite() {
-  sudo yum -y install ${SUITE} - ${DCFABRIC_SUITE_VERSION} --skip-broken
+  sudo yum -y install ${SUITE} - ${DCFABRIC_SUITE_VERSION}
 }
 
 setup_ipfabric_automation_suite() {

--- a/scripts/dcfabric-suite-installer-el7.sh
+++ b/scripts/dcfabric-suite-installer-el7.sh
@@ -14,6 +14,7 @@ BRANCH='master'
 REPO_NAME='enterprise'
 
 SUITE='dcfabric-suite'
+DCFABRIC_SUITE_VERSION=''
 
 NO_LICENSE_BANNER="
 LICENSE KEY not provided. You'll need a license key to install Brocade Workflow Composer (BWC).
@@ -140,6 +141,7 @@ get_full_pkg_versions() {
     fi
 
     SUITE=${IPF_VER}
+    DCFABRIC_SUITE_VERSION="=${IPF_VER}"
     echo "##########################################################"
     echo "#### Following versions of packages will be installed ####"
     echo "${IPFABRIC_SUITE_PKG}"
@@ -148,11 +150,12 @@ get_full_pkg_versions() {
 }
 
 install_network_essentials_pack() {
-  sudo st2 pack install network_essentials=${IPFABRIC_SUITE_VERSION}
+  sudo yum -y install gcc
+  sudo st2 pack install network_essentials=${DCFABRIC_SUITE_VERSION}
 }
 
 install_ipfabric_automation_suite() {
-  sudo yum -y install ${SUITE}
+  sudo yum -y install ${SUITE} - ${DCFABRIC_SUITE_VERSION} --skip-broken
 }
 
 setup_ipfabric_automation_suite() {


### PR DESCRIPTION
I still see this when I run the centos installation script, This is
something that might need changes to the rpm spec file in the
bwc-topology repo.

Error: Package: bwc-topology-1.0.0-2.x86_64 (StackStorm_enterprise)
           Requires: /home/ubuntu/virtualenvs/venv-system/bin/python
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest