### PR TITLE
v2.2: Enable specifying version for bwc-enterprise and dependencies

### DIFF
--- a/scripts/bwc-installer-deb.sh
+++ b/scripts/bwc-installer-deb.sh
@@ -116,17 +116,44 @@ get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
   then
 
-    local BWC_VER=$(apt-cache show bwc-enterprise | grep Version | awk '{print $2}' | grep $VERSION | sort --version-sort | tail -n 1)
+    local BWC_VER=$(apt-cache show bwc-enterprise | grep Version | awk '{print $2}' | grep ^${VERSION//./\\.} | sort --version-sort | tail -n 1)
     if [ -z "$BWC_VER" ]; then
       echo "Could not find requested version of bwc-enterprise!!!"
       sudo apt-cache policy bwc-enterprise
       exit 3
     fi
 
+    local ST2FLOW_VER=$(apt-cache show st2flow | grep Version | awk '{print $2}' | grep ^${VERSION//./\\.} | sort --version-sort | tail -n 1)
+    if [ -z "$ST2FLOW_VER" ]; then
+      echo "Could not find requested version of st2flow!!!"
+      sudo apt-cache policy st2flow
+      exit 3
+    fi
+
+    local ST2LDAP_VER=$(apt-cache show st2-auth-ldap | grep Version | awk '{print $2}' | grep ^${VERSION//./\\.} | sort --version-sort | tail -n 1)
+    if [ -z "$ST2LDAP_VER" ]; then
+      echo "Could not find requested version of st2-auth-ldap!!!"
+      sudo apt-cache policy st2-auth-ldap
+      exit 3
+    fi
+
+    local BWCUI_VER=$(apt-cache show bwc-ui | grep Version | awk '{print $2}' | grep ^${VERSION//./\\.} | sort --version-sort | tail -n 1)
+    if [ -z "$BWC_VER" ]; then
+      echo "Could not find requested version of bwc-ui!!!"
+      sudo apt-cache policy bwc-ui
+      exit 3
+    fi
+
     BWC_ENTERPRISE_VERSION="=${BWC_VER}"
+    ST2FLOW_PKG_VERSION="=${ST2FLOW_VER}"
+    ST2LDAP_PKG_VERSION="=${ST2LDAP_VER}"
+    BWCUI_PKG_VERSION="=${BWCUI_VER}"
     echo "##########################################################"
     echo "#### Following versions of packages will be installed ####"
     echo "bwc-enterprise${BWC_ENTERPRISE_VERSION}"
+    echo "st2flow${ST2FLOW_PKG_VERSION}"
+    echo "st2-auth-ldap${ST2LDAP_PKG_VERSION}"
+    echo "bwc-ui${BWCUI_PKG_VERSION}"
     echo "##########################################################"
   fi
 }
@@ -134,7 +161,12 @@ get_full_pkg_versions() {
 install_bwc_enterprise() {
   # Install BWC
   sudo apt-get update
-  sudo apt-get -y install bwc-enterprise${BWC_ENTERPRISE_VERSION}
+  if [ "$VERSION" != '' ];
+  then
+    sudo apt-get -y install bwc-enterprise${BWC_ENTERPRISE_VERSION} st2flow${ST2FLOW_PKG_VERSION} st2-auth-ldap${ST2LDAP_PKG_VERSION} bwc-ui${BWCUI_PKG_VERSION}
+  else
+    sudo apt-get -y install bwc-enterprise${BWC_ENTERPRISE_VERSION}
+  fi
 }
 
 enable_and_configure_rbac() {

--- a/scripts/bwc-installer-el6.sh
+++ b/scripts/bwc-installer-el6.sh
@@ -116,14 +116,35 @@ get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
   then
 
-    local BWC_VER=$(repoquery --nvr --show-duplicates ${BWC_ENTERPRISE_PKG} | grep ${VERSION} | sort --version-sort | tail -n 1)
+    local BWC_VER=$(repoquery --nvr --show-duplicates ${BWC_ENTERPRISE_PKG} | grep -F bwc-enterprise-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$BWC_VER" ]; then
       echo "Could not find requested version of ${BWC_ENTERPRISE_PKG}!!!"
       sudo repoquery --nvr --show-duplicates ${BWC_ENTERPRISE_PKG}
       exit 3
     fi
 
-    BWC_ENTERPRISE_PKG=${BWC_VER}
+    local ST2FLOW_VER=$(repoquery --nvr --show-duplicates st2flow | grep -F st2flow-${VERSION} | sort --version-sort | tail -n 1)
+    if [ -z "$ST2FLOW_VER" ]; then
+      echo "Could not find requested version of st2flow!!!"
+      sudo repoquery --nvr --show-duplicates st2flow
+      exit 3
+    fi
+
+    local ST2LDAP_VER=$(repoquery --nvr --show-duplicates st2-auth-ldap | grep -F st2-auth-ldap-${VERSION} | sort --version-sort | tail -n 1)
+    if [ -z "$ST2LDAP_VER" ]; then
+      echo "Could not find requested version of st2-auth-ldap!!!"
+      sudo repoquery --nvr --show-duplicates st2-auth-ldap
+      exit 3
+    fi
+
+    local BWCUI_VER=$(repoquery --nvr --show-duplicates bwc-ui | grep -F bwc-ui-${VERSION} | sort --version-sort | tail -n 1)
+    if [ -z "$BWCUI_VER" ]; then
+      echo "Could not find requested version of bwc-ui!!!"
+      sudo repoquery --nvr --show-duplicates bwc-ui
+      exit 3
+    fi
+
+    BWC_ENTERPRISE_PKG="${BWC_VER} ${ST2FLOW_VER} ${ST2LDAP_VER} ${BWCUI_VER}"
     echo "##########################################################"
     echo "#### Following versions of packages will be installed ####"
     echo "${BWC_ENTERPRISE_PKG}"

--- a/scripts/bwc-installer-el7.sh
+++ b/scripts/bwc-installer-el7.sh
@@ -116,14 +116,35 @@ get_full_pkg_versions() {
   if [ "$VERSION" != '' ];
   then
 
-    local BWC_VER=$(repoquery --nvr --show-duplicates ${BWC_ENTERPRISE_PKG} | grep ${VERSION} | sort --version-sort | tail -n 1)
+    local BWC_VER=$(repoquery --nvr --show-duplicates ${BWC_ENTERPRISE_PKG} | grep -F bwc-enterprise-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$BWC_VER" ]; then
       echo "Could not find requested version of ${BWC_ENTERPRISE_PKG}!!!"
       sudo repoquery --nvr --show-duplicates ${BWC_ENTERPRISE_PKG}
       exit 3
     fi
 
-    BWC_ENTERPRISE_PKG=${BWC_VER}
+    local ST2FLOW_VER=$(repoquery --nvr --show-duplicates st2flow | grep -F st2flow-${VERSION} | sort --version-sort | tail -n 1)
+    if [ -z "$ST2FLOW_VER" ]; then
+      echo "Could not find requested version of st2flow!!!"
+      sudo repoquery --nvr --show-duplicates st2flow
+      exit 3
+    fi
+
+    local ST2LDAP_VER=$(repoquery --nvr --show-duplicates st2-auth-ldap | grep -F st2-auth-ldap-${VERSION} | sort --version-sort | tail -n 1)
+    if [ -z "$ST2LDAP_VER" ]; then
+      echo "Could not find requested version of st2-auth-ldap!!!"
+      sudo repoquery --nvr --show-duplicates st2-auth-ldap
+      exit 3
+    fi
+
+    local BWCUI_VER=$(repoquery --nvr --show-duplicates bwc-ui | grep -F bwc-ui-${VERSION} | sort --version-sort | tail -n 1)
+    if [ -z "$BWCUI_VER" ]; then
+      echo "Could not find requested version of bwc-ui!!!"
+      sudo repoquery --nvr --show-duplicates bwc-ui
+      exit 3
+    fi
+
+    BWC_ENTERPRISE_PKG="${BWC_VER} ${ST2FLOW_VER} ${ST2LDAP_VER} ${BWCUI_VER}"
     echo "##########################################################"
     echo "#### Following versions of packages will be installed ####"
     echo "${BWC_ENTERPRISE_PKG}"


### PR DESCRIPTION
This fix allows the user to specify a version of BWC to install. This was always supported with ST2, but was broken with BWC packages. This was due to the use of the bwc-enterprise meta-package. Dependency resolution fails if you specify a version for the meta package. Need to specify it for all packages.

Now if the user passes `--version=2.2.1`, it will succeed.

Plan is to merge this against v2.2 first, test it out, if that's OK, we'll create a v2.3 branch with same thing, check that out, then we can later merge to master. 