### PR TITLE
Allow installing BWC Enterprise on top of existing st2 Community

### DIFF
--- a/scripts/bwc-installer.sh
+++ b/scripts/bwc-installer.sh
@@ -144,12 +144,12 @@ get_version_branch() {
 
 # Check if .deb package(s) is installed
 deb_is_installed() {
-  dpkg --status $1 > /dev/null 2>&1
+  dpkg --status $@ > /dev/null 2>&1
 }
 
 # Check if .rpm package(s) is installed
 rpm_is_installed() {
-  rpm -q --quiet $1
+  rpm -q --quiet $@
 }
 
 if [[ "$VERSION" != '' ]]; then

--- a/scripts/bwc-installer.sh
+++ b/scripts/bwc-installer.sh
@@ -144,7 +144,10 @@ get_version_branch() {
 
 # Check if .deb package(s) is installed
 deb_is_installed() {
-  dpkg --status $@ > /dev/null 2>&1
+  expected_packages=$(echo $@ | awk '{print NF}')
+  installed_packages=$(dpkg-query -W -f='${Status}\n' $@ 2>/dev/null | grep -c 'install ok installed')
+
+  [[ "$expected_packages" == "$installed_packages" ]]
 }
 
 # Check if .rpm package(s) is installed

--- a/scripts/bwc-installer.sh
+++ b/scripts/bwc-installer.sh
@@ -195,7 +195,7 @@ else
   exit 2
 fi
 
-if ${PKG_TYPE}_is_installed st2 st2mistral st2web; then
+if ${PKG_TYPE}_is_installed st2 st2mistral; then
     echo 'StackStorm Community version is already installed.'
     echo 'Proceeding with BWC Enterprise install ...'
 elif ! curl --output /dev/null --silent --fail ${ST2_COMMUNITY_INSTALLER}; then


### PR DESCRIPTION
Closes #39 

Don't install StackStorm community version if it was already installed.
This way, allow BWC Enterprise installer to be applied on top of existing Community installation.