### PR TITLE
Fix PackageCloud license check

### DIFF
--- a/scripts/bwc-installer.sh
+++ b/scripts/bwc-installer.sh
@@ -104,7 +104,7 @@ setup_args() {
   hash curl 2>/dev/null || { echo >&2 "'curl' is not installed. Aborting."; exit 1; }
 
   # Check if provided license key is valid
-  LICENSE_CHECK=`curl --head --silent --output /dev/null --fail --retry 3 "https://${LICENSE_KEY}:@packagecloud.io/install/repositories/StackStorm/${REPO_NAME}/script.deb.sh"`
+  LICENSE_CHECK=`curl --silent --output /dev/null --fail --retry 3 "https://${LICENSE_KEY}:@packagecloud.io/install/repositories/StackStorm/${REPO_NAME}/script.deb.sh"`
   if [ $? -ne 0 ]; then
     echo -e "
       LICENSE: ${LICENSE_KEY} not valid.


### PR DESCRIPTION
Fix check license script as PackageCloud started returning 500s on HEAD HTTP requests

```
$ curl --head -v "https://$BWC_LICENSE:@packagecloud.io/install/repositories/StackStorm/enterprise/script.deb.sh"
HTTP/1.1 500 Internal Server Error
Date: Fri, 08 Mar 2019 16:34:14 GMT
Connection: keep-alive
Server: nginx

```

If no `--head` is passed, PackageCloud responds with `200 OK`.

This could be temporary, could be not. Anyways the patch is here.