### PR TITLE
Update installer scripts to also look for "st2-rbac-backend" package and enable enterprise backend

### DIFF
--- a/scripts/bwc-installer-deb.sh
+++ b/scripts/bwc-installer-deb.sh
@@ -137,6 +137,13 @@ get_full_pkg_versions() {
       exit 3
     fi
 
+    local ST2_RBAC_BACKEND_VER=$(apt-cache show st2-rbac-backend | grep Version | awk '{print $2}' | grep ^${VERSION//./\\.} | sort --version-sort | tail -n 1)
+    if [ -z "$ST2_RBAC_BACKEND_VER" ]; then
+      echo "Could not find requested version of st2-rbac-backend!!!"
+      sudo apt-cache policy st2-rbac-backend
+      exit 3
+    fi
+
     local BWCUI_VER=$(apt-cache show bwc-ui | grep Version | awk '{print $2}' | grep ^${VERSION//./\\.} | sort --version-sort | tail -n 1)
     if [ -z "$BWC_VER" ]; then
       echo "Could not find requested version of bwc-ui!!!"
@@ -147,12 +154,14 @@ get_full_pkg_versions() {
     BWC_ENTERPRISE_VERSION="=${BWC_VER}"
     ST2FLOW_PKG_VERSION="=${ST2FLOW_VER}"
     ST2LDAP_PKG_VERSION="=${ST2LDAP_VER}"
+    ST2_RBAC_BACKEND_PKG_VERSION="=${ST2_RBAC_BACKEND_VER}"
     BWCUI_PKG_VERSION="=${BWCUI_VER}"
     echo "##########################################################"
     echo "#### Following versions of packages will be installed ####"
     echo "bwc-enterprise${BWC_ENTERPRISE_VERSION}"
     echo "st2flow${ST2FLOW_PKG_VERSION}"
     echo "st2-auth-ldap${ST2LDAP_PKG_VERSION}"
+    echo "st2-rbac-backend${ST2_RBAC_BACKEND_PKG_VERSION}"
     echo "bwc-ui${BWCUI_PKG_VERSION}"
     echo "##########################################################"
   fi
@@ -163,7 +172,7 @@ install_enterprise() {
   sudo apt-get update
   if [ "$VERSION" != '' ];
   then
-    sudo apt-get -y install bwc-enterprise${BWC_ENTERPRISE_VERSION} st2flow${ST2FLOW_PKG_VERSION} st2-auth-ldap${ST2LDAP_PKG_VERSION} bwc-ui${BWCUI_PKG_VERSION}
+    sudo apt-get -y install bwc-enterprise${BWC_ENTERPRISE_VERSION} st2flow${ST2FLOW_PKG_VERSION} st2-auth-ldap${ST2LDAP_PKG_VERSION} st2-rbac-backend${ST2_RBAC_BACKEND_PKG_VERSION} bwc-ui${BWCUI_PKG_VERSION}
   else
     sudo apt-get -y install bwc-enterprise${BWC_ENTERPRISE_VERSION}
   fi
@@ -173,6 +182,7 @@ enable_and_configure_rbac() {
   # Enable RBAC
   sudo apt-get install -y crudini
   sudo crudini --set /etc/st2/st2.conf rbac enable 'True'
+  sudo crudini --set /etc/st2/st2.conf rbac backend 'enterprise'
 
   # Write role assignment for admin user
   ROLE_ASSIGNMENT_FILE="/opt/stackstorm/rbac/assignments/${USERNAME}.yaml"

--- a/scripts/bwc-installer-el6.sh
+++ b/scripts/bwc-installer-el6.sh
@@ -137,6 +137,13 @@ get_full_pkg_versions() {
       exit 3
     fi
 
+    local ST2_RBAC_BACKEND_VER=$(repoquery --nvr --show-duplicates st2-rbac-backend | grep -F st2-rbac-backend-${VERSION} | sort --version-sort | tail -n 1)
+    if [ -z "$ST2_RBAC_BACKEND_VER" ]; then
+      echo "Could not find requested version of st2-rbac-backend!!!"
+      sudo repoquery --nvr --show-duplicates st2-rbac-backend
+      exit 3
+    fi
+
     local BWCUI_VER=$(repoquery --nvr --show-duplicates bwc-ui | grep -F bwc-ui-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$BWCUI_VER" ]; then
       echo "Could not find requested version of bwc-ui!!!"
@@ -144,7 +151,7 @@ get_full_pkg_versions() {
       exit 3
     fi
 
-    BWC_ENTERPRISE_PKG="${BWC_VER} ${ST2FLOW_VER} ${ST2LDAP_VER} ${BWCUI_VER}"
+    BWC_ENTERPRISE_PKG="${BWC_VER} ${ST2FLOW_VER} ${ST2LDAP_VER} ${ST2_RBAC_BACKEND_VER} ${BWCUI_VER}"
     echo "##########################################################"
     echo "#### Following versions of packages will be installed ####"
     echo "${BWC_ENTERPRISE_PKG}"
@@ -161,6 +168,7 @@ enable_and_configure_rbac() {
   # Enable RBAC
   sudo yum -y install crudini
   sudo crudini --set /etc/st2/st2.conf rbac enable 'True'
+  sudo crudini --set /etc/st2/st2.conf rbac backend 'enterprise'
 
   # Write role assignment for admin user
   ROLE_ASSIGNMENT_FILE="/opt/stackstorm/rbac/assignments/${USERNAME}.yaml"

--- a/scripts/bwc-installer-el6.sh
+++ b/scripts/bwc-installer-el6.sh
@@ -97,6 +97,14 @@ setup_args() {
     echo "########################################################"
     REPO_NAME="${REPO_NAME}-unstable"
   fi
+
+  # NOTE: st2-rbac-backend package has been introduced in v3.0.0(dev) so we only try to install
+  # it if version >= 3.0.0[dev]
+  if [[ "$VERSION" =~ ^[3-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "$VERSION" =~ ^[3-9]+\.[0-9]+dev$ ]]; then
+    IS_V300_OR_ABOVE="true"
+  else
+    IS_V300_OR_ABOVE="false"
+  fi
 }
 
 setup_package_cloud_repo() {
@@ -137,11 +145,14 @@ get_full_pkg_versions() {
       exit 3
     fi
 
-    local ST2_RBAC_BACKEND_VER=$(repoquery --nvr --show-duplicates st2-rbac-backend | grep -F st2-rbac-backend-${VERSION} | sort --version-sort | tail -n 1)
-    if [ -z "$ST2_RBAC_BACKEND_VER" ]; then
-      echo "Could not find requested version of st2-rbac-backend!!!"
-      sudo repoquery --nvr --show-duplicates st2-rbac-backend
-      exit 3
+    # NOTE: This package has been introduced in v3.0.0(dev) version
+    if [ "${IS_V300_OR_ABOVE}" = "true" ]; then
+      local ST2_RBAC_BACKEND_VER=$(repoquery --nvr --show-duplicates st2-rbac-backend | grep -F st2-rbac-backend-${VERSION} | sort --version-sort | tail -n 1)
+      if [ -z "$ST2_RBAC_BACKEND_VER" ]; then
+        echo "Could not find requested version of st2-rbac-backend!!!"
+        sudo repoquery --nvr --show-duplicates st2-rbac-backend
+        exit 3
+      fi
     fi
 
     local BWCUI_VER=$(repoquery --nvr --show-duplicates bwc-ui | grep -F bwc-ui-${VERSION} | sort --version-sort | tail -n 1)
@@ -151,7 +162,12 @@ get_full_pkg_versions() {
       exit 3
     fi
 
-    BWC_ENTERPRISE_PKG="${BWC_VER} ${ST2FLOW_VER} ${ST2LDAP_VER} ${ST2_RBAC_BACKEND_VER} ${BWCUI_VER}"
+    if [ "${IS_V300_OR_ABOVE}" = "true" ]; then
+      BWC_ENTERPRISE_PKG="${BWC_VER} ${ST2FLOW_VER} ${ST2LDAP_VER} ${ST2_RBAC_BACKEND_VER} ${BWCUI_VER}"
+    else
+      BWC_ENTERPRISE_PKG="${BWC_VER} ${ST2FLOW_VER} ${ST2LDAP_VER} ${BWCUI_VER}"
+    fi
+
     echo "##########################################################"
     echo "#### Following versions of packages will be installed ####"
     echo "${BWC_ENTERPRISE_PKG}"

--- a/scripts/bwc-installer-el7.sh
+++ b/scripts/bwc-installer-el7.sh
@@ -137,6 +137,13 @@ get_full_pkg_versions() {
       exit 3
     fi
 
+    local ST2_RBAC_BACKEND_VER=$(repoquery --nvr --show-duplicates st2-rbac-backend | grep -F st2-rbac-backend-${VERSION} | sort --version-sort | tail -n 1)
+    if [ -z "$ST2_RBAC_BACKEND_VER" ]; then
+      echo "Could not find requested version of st2-rbac-backend!!!"
+      sudo repoquery --nvr --show-duplicates st2-rbac-backend
+      exit 3
+    fi
+
     local BWCUI_VER=$(repoquery --nvr --show-duplicates bwc-ui | grep -F bwc-ui-${VERSION} | sort --version-sort | tail -n 1)
     if [ -z "$BWCUI_VER" ]; then
       echo "Could not find requested version of bwc-ui!!!"
@@ -144,7 +151,7 @@ get_full_pkg_versions() {
       exit 3
     fi
 
-    BWC_ENTERPRISE_PKG="${BWC_VER} ${ST2FLOW_VER} ${ST2LDAP_VER} ${BWCUI_VER}"
+    BWC_ENTERPRISE_PKG="${BWC_VER} ${ST2FLOW_VER} ${ST2LDAP_VER} ${ST2_RBAC_BACKEND_VER} ${BWCUI_VER}"
     echo "##########################################################"
     echo "#### Following versions of packages will be installed ####"
     echo "${BWC_ENTERPRISE_PKG}"
@@ -161,6 +168,7 @@ enable_and_configure_rbac() {
   # Enable RBAC
   sudo yum -y install crudini
   sudo crudini --set /etc/st2/st2.conf rbac enable 'True'
+  sudo crudini --set /etc/st2/st2.conf rbac backend 'enterprise'
 
   # Write role assignment for admin user
   ROLE_ASSIGNMENT_FILE="/opt/stackstorm/rbac/assignments/${USERNAME}.yaml"

--- a/scripts/bwc-installer-el7.sh
+++ b/scripts/bwc-installer-el7.sh
@@ -97,6 +97,14 @@ setup_args() {
     echo "########################################################"
     REPO_NAME="${REPO_NAME}-unstable"
   fi
+
+  # NOTE: st2-rbac-backend package has been introduced in v3.0.0(dev) so we only try to install
+  # it if version >= 3.0.0[dev]
+  if [[ "$VERSION" =~ ^[3-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "$VERSION" =~ ^[3-9]+\.[0-9]+dev$ ]]; then
+    IS_V300_OR_ABOVE="true"
+  else
+    IS_V300_OR_ABOVE="false"
+  fi
 }
 
 setup_package_cloud_repo() {
@@ -137,11 +145,14 @@ get_full_pkg_versions() {
       exit 3
     fi
 
-    local ST2_RBAC_BACKEND_VER=$(repoquery --nvr --show-duplicates st2-rbac-backend | grep -F st2-rbac-backend-${VERSION} | sort --version-sort | tail -n 1)
-    if [ -z "$ST2_RBAC_BACKEND_VER" ]; then
-      echo "Could not find requested version of st2-rbac-backend!!!"
-      sudo repoquery --nvr --show-duplicates st2-rbac-backend
-      exit 3
+    # NOTE: This package has been introduced in v3.0.0(dev) version
+    if [ "${IS_V300_OR_ABOVE}" = "true" ]; then
+      local ST2_RBAC_BACKEND_VER=$(repoquery --nvr --show-duplicates st2-rbac-backend | grep -F st2-rbac-backend-${VERSION} | sort --version-sort | tail -n 1)
+      if [ -z "$ST2_RBAC_BACKEND_VER" ]; then
+        echo "Could not find requested version of st2-rbac-backend!!!"
+        sudo repoquery --nvr --show-duplicates st2-rbac-backend
+        exit 3
+      fi
     fi
 
     local BWCUI_VER=$(repoquery --nvr --show-duplicates bwc-ui | grep -F bwc-ui-${VERSION} | sort --version-sort | tail -n 1)
@@ -151,7 +162,12 @@ get_full_pkg_versions() {
       exit 3
     fi
 
-    BWC_ENTERPRISE_PKG="${BWC_VER} ${ST2FLOW_VER} ${ST2LDAP_VER} ${ST2_RBAC_BACKEND_VER} ${BWCUI_VER}"
+    if [ "${IS_V300_OR_ABOVE}" = "true" ]; then
+      BWC_ENTERPRISE_PKG="${BWC_VER} ${ST2FLOW_VER} ${ST2LDAP_VER} ${ST2_RBAC_BACKEND_VER} ${BWCUI_VER}"
+    else
+      BWC_ENTERPRISE_PKG="${BWC_VER} ${ST2FLOW_VER} ${ST2LDAP_VER} ${BWCUI_VER}"
+    fi
+
     echo "##########################################################"
     echo "#### Following versions of packages will be installed ####"
     echo "${BWC_ENTERPRISE_PKG}"


### PR DESCRIPTION
This pull request updates installer script to also look for the new ``st2-rbac-backend`` package and enable enterprise RBAC backend by setting ``rbac.backend`` config option to ``enterprise``.